### PR TITLE
src/config.cpp: include fcntl.h for O_RDONLY, open() and popen()

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <fstream>
 #include <algorithm>
+#include <fcntl.h>
 
 std::ofstream out;
 


### PR DESCRIPTION
Fixes compilation on musl libc

```
g++ -Iwf-config@sha -I. -I.. -I../include/wayfire -I/usr/include/libevdev-1.0/ -I/usr/include/elogind -I/usr/include/libdrm -I/usr/include/pixman-1 -flto -fdiagnostics-color=always -DNDEBUG -pipe -D_FILE_OFFSET_BITS=64 -std=c++11 -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -fPIC  -MD -MQ 'wf-config@sha/src_config.cpp.o' -MF 'wf-config@sha/src_config.cpp.o.d' -o 'wf-config@sha/src_config.cpp.o' -c ../src/config.cpp
../src/config.cpp: In member function 'void wayfire_config::reload_config()':
../src/config.cpp:441:35: error: 'O_RDONLY' was not declared in this scope
     auto fd = open(fname.c_str(), O_RDONLY);
                                   ^~~~~~~~
../src/config.cpp:441:15: error: 'open' was not declared in this scope
     auto fd = open(fname.c_str(), O_RDONLY);
               ^~~~
../src/config.cpp:441:15: note: suggested alternative: 'popen'
     auto fd = open(fname.c_str(), O_RDONLY);
               ^~~~
               popen
../src/config.cpp: In member function 'void wayfire_config::save_config(std::__cxx11::string)':
../src/config.cpp:506:34: error: 'O_RDONLY' was not declared in this scope
     auto fd = open(file.c_str(), O_RDONLY);
                                  ^~~~~~~~
../src/config.cpp:506:15: error: 'open' was not declared in this scope
     auto fd = open(file.c_str(), O_RDONLY);
               ^~~~
../src/config.cpp:506:15: note: suggested alternative: 'popen'
     auto fd = open(file.c_str(), O_RDONLY);
               ^~~~
               popen
[3/4] Compiling C++ object 'wf-config@sha/src_parse.cpp.o'.
ninja: build stopped: subcommand failed.
```