### PR TITLE
Add fallback for wlroots

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project(
 )
 
 evdev = dependency('libevdev')
-wlroots = dependency('wlroots', version: '>=0.8.0')
+wlroots = dependency('wlroots', version: '>=0.8.0', fallback : ['wlroots', 'wlroots'])
 
 sources = [
     'src/config.cpp',


### PR DESCRIPTION
This allows wlroots to be built as a subproject of wayfire
and find the dependency.