### PR TITLE
Add missing fcntl.h includes

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 
 #include <sys/file.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <dirent.h>
 

--- a/test/file_test.cpp
+++ b/test/file_test.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "doctest.h"
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/file.h>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
Seems required on musl libc (Alpine Linux):

```
 ../subprojects/wf-config/test/file_test.cpp: In function 'void _DOCTEST_ANON_FUNC_8()':
../subprojects/wf-config/test/file_test.cpp:136:44: error: 'O_RDWR' was not declared in this scope
  136 |         int fd = open(test_config.c_str(), O_RDWR);
      |                                            ^~~~~~
../subprojects/wf-config/test/file_test.cpp:136:18: error: 'open' was not declared in this scope; did you mean 'popen'?
  136 |         int fd = open(test_config.c_str(), O_RDWR);
      |                  ^~~~
      |                  popen
../subprojects/wf-config/test/file_test.cpp: In function 'void _DOCTEST_ANON_FUNC_12()':
../subprojects/wf-config/test/file_test.cpp:211:40: error: 'O_RDWR' was not declared in this scope
  211 |     int fd = open(test_config.c_str(), O_RDWR);
      |                                        ^~~~~~
../subprojects/wf-config/test/file_test.cpp:211:14: error: 'open' was not declared in this scope; did you mean 'popen'?
  211 |     int fd = open(test_config.c_str(), O_RDWR);
      |              ^~~~
      |              popen
```