### PR TITLE
Add soversion field to meson.build.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,8 @@ lib_wfconfig = library('wf-config',
     dependencies: [evdev, glm, libxml2],
     include_directories: wfconfig_inc,
     install: true,
-    version: meson.project_version())
+    version: meson.project_version(),
+    soversion: '1')
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(


### PR DESCRIPTION
Helps packagers in avoiding breaks due to ABI changes.

Fixes #24, but I don't know how ABI should be tracked.