### PR TITLE
meson.build: update version to 0.5.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'wf-config',
 	'cpp',
-	version: '0.4.0',
+	version: '0.5.0',
 	license: 'MIT',
 	meson_version: '>=0.43.0',
 	default_options: [


### PR DESCRIPTION
This is to leave stuff ready for the 0.5.0 update.