### PR TITLE
Support for object section descriptions

### DIFF
--- a/include/wayfire/config/option.hpp
+++ b/include/wayfire/config/option.hpp
@@ -23,6 +23,9 @@ class option_base_t
     /** @return The name of the option */
     std::string get_name() const;
 
+    /** @return A copy of the option */
+    virtual std::shared_ptr<option_base_t> clone_option() const = 0;
+
     /**
      * Set the option value from the given string.
      * Invalid values are ignored.
@@ -154,6 +157,21 @@ class option_t : public option_base_t,
     option_t(const std::string& name, Type def_value)
         : option_base_t(name), default_value(def_value), value(default_value)
     { }
+
+    /**
+     * Create a copy of the option.
+     */
+    virtual std::shared_ptr<option_base_t> clone_option() const override
+    {
+        auto result = std::make_shared<option_t>(get_name(), get_default_value());
+        result->set_value(get_value());
+        if constexpr (std::is_arithmetic<Type>::value)
+        {
+            result->minimum = this->minimum;
+            result->maximum = this->maximum;
+        }
+        return result;
+    }
 
     /**
      * Set the value of the option from the given string.

--- a/include/wayfire/config/section.hpp
+++ b/include/wayfire/config/section.hpp
@@ -27,6 +27,9 @@ class section_t
     /** @return The name of the config section. */
     std::string get_name() const;
 
+    /** @return A deep copy of the config section with a new name. */
+    std::shared_ptr<section_t> clone_with_name(const std::string name) const;
+
     /**
      * @return The option with the given name, or nullptr if no such option
      * has been added yet.

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -21,6 +21,16 @@ std::string wf::config::section_t::get_name() const
     return this->priv->name;
 }
 
+std::shared_ptr<wf::config::section_t>
+wf::config::section_t::clone_with_name(const std::string name) const
+{
+    auto result = std::make_shared<wf::config::section_t>(name);
+    for (auto& option : priv->options)
+        result->register_new_option(option.second->clone_option());
+
+    return result;
+}
+
 std::shared_ptr<wf::config::option_base_t>
 wf::config::section_t::get_option_or(const std::string& name)
 {

--- a/src/xml.cpp
+++ b/src/xml.cpp
@@ -259,10 +259,11 @@ std::shared_ptr<wf::config::section_t>
     wf::config::xml::create_section_from_xml_node(xmlNodePtr node)
 {
     if (node->type != XML_ELEMENT_NODE ||
-        (const char*)node->name != std::string{"plugin"})
+        ((const char*)node->name != std::string{"plugin"} &&
+         (const char*)node->name != std::string{"object"}))
     {
         LOGE("Could not parse ", node->doc->URL,
-            ": line ", node->line, " is not a plugin element.");
+            ": line ", node->line, " is not a plugin/object element.");
         return nullptr;
     }
 

--- a/test/file_test.cpp
+++ b/test/file_test.cpp
@@ -228,6 +228,7 @@ TEST_CASE("wf::config::build_configuration")
     auto o3 = config.get_option("section2/option3");
     auto o4 = config.get_option("section2/option4");
     auto o5 = config.get_option("section2/option5");
+    auto o6 = config.get_option("sectionobj:objtest/option6");
 
     REQUIRE(o4);
     REQUIRE(o5);
@@ -239,19 +240,23 @@ TEST_CASE("wf::config::build_configuration")
     CHECK(std::dynamic_pointer_cast<option_t<std::string>> (o3) != nullptr);
     CHECK(std::dynamic_pointer_cast<option_t<std::string>> (o4) != nullptr);
     CHECK(std::dynamic_pointer_cast<option_t<std::string>> (o5) != nullptr);
+    CHECK(std::dynamic_pointer_cast<option_t<int>> (o6) != nullptr);
 
     CHECK(o4->get_value_str() == "DoesNotExistInConfig");
     CHECK(o5->get_value_str() == "Option5Sys");
+    CHECK(o6->get_value_str() == "10"); // bounds from xml applied
 
     o1->reset_to_default();
     o2->reset_to_default();
     o3->reset_to_default();
     o4->reset_to_default();
     o5->reset_to_default();
+    o6->reset_to_default();
 
     CHECK(o1->get_value_str() == "4");
     CHECK(o2->get_value_str() == "XMLDefault");
     CHECK(o3->get_value_str() == "");
     CHECK(o4->get_value_str() == "DoesNotExistInConfig");
     CHECK(o5->get_value_str() == "Option5Sys");
+    CHECK(o6->get_value_str() == "1");
 }

--- a/test/int_test/config.ini
+++ b/test/int_test/config.ini
@@ -7,3 +7,7 @@ option1 = 12
 
 option2 = opt2
 option3 = DoesNotExistInXML \# \\
+
+[sectionobj:objtest]
+
+option6 = 11

--- a/test/int_test/xml/sectionobj.xml
+++ b/test/int_test/xml/sectionobj.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<wayfire>
+  <object name="sectionobj">
+    <category>General</category>
+    <option name="option6" type="int">
+      <default>1</default>
+      <min>0</min>
+      <max>10</max>
+    </option>
+  </object>
+</wayfire>

--- a/test/option_base_test.cpp
+++ b/test/option_base_test.cpp
@@ -8,6 +8,7 @@ class option_base_stub_t : public wf::config::option_base_t
     option_base_stub_t(std::string name)
         : option_base_t(name) {}
 
+    std::shared_ptr<option_base_t> clone_option() const override { return nullptr; }
     bool set_default_value_str(const std::string&) override { return true; }
     bool set_value_str(const std::string&) override { return false; }
     void reset_to_default() override {}

--- a/test/section_test.cpp
+++ b/test/section_test.cpp
@@ -34,4 +34,11 @@ TEST_CASE("wf::config::section_t")
     CHECK(reg_opts.back() == intopt2);
     section.unregister_option(intopt2);
     CHECK(section.get_registered_options().empty());
+
+    section.register_new_option(intopt);
+    auto clone = section.clone_with_name("Cloned_Section");
+    CHECK(clone->get_name() == "Cloned_Section");
+    CHECK(clone->get_option_or("IntOption") != intopt);
+    CHECK(clone->get_option_or("IntOption")->get_name() == intopt->get_name());
+    CHECK(clone->get_option_or("IntOption")->get_value_str() == intopt->get_value_str());
 }

--- a/test/xml_test.cpp
+++ b/test/xml_test.cpp
@@ -323,6 +323,6 @@ TEST_CASE("wf::config::xml::create_section")
     {
         auto section = initialize_section(xml_section_bad_tag);
         CHECK(section == nullptr);
-        EXPECT_LINE(log, "is not a plugin element");
+        EXPECT_LINE(log, "is not a plugin/object element");
     }
 }


### PR DESCRIPTION
This is a prototype implementation of my idea for good support of configuring arbitrary instances of an object, like outputs and inputs in core, wallpapers in my upcoming wallpaper plugin, etc.

My explanations on IRC might have made it seem more complicated, but it really is simple, the idea is: we use sections for objects **like core already does for outputs** but we **add conventions/metadata** to make it possible for metadata consumers (wf-gsettings, wcm) to create automatic UI for these sections, and **implement section cloning** to make the metadata actually useful at runtime — i.e. **xml will be used for types/defaults/bounds on these dynamic sections** and stuff like `add_if_missing` that core does for outputs is no longer necessary!

## Example usage: outputs in core

example text config part:

```ini
[core.output:WL-1]
scale = 2.0
```

`metadata/core.output.xml`: (note: `object` element is equivalent to `plugin` but can be treated differently by consumers — and looks better than something like `<plugin name="xxx" relocatable="true">` IMO, but syntax can be bikeshedded endlessly :D)

```xml
<?xml version="1.0"?>
<wayfire>
	<object name="core.output">
		<_short>Output</_short>
		<_long>Display output settings.</_long>
		<category>General</category>
		<option name="mode" type="string">
			<_short>Mode</_short>
			<_long>Sets the resolution and refresh rate for the display.</_long>
			<default>default</default>
		</option>
		<option name="scale" type="double">
			<_short>Render scale</_short>
			<_long>Sets the rendering scale for the display. Can be fractional.</_long>
			<default>1.0</default>
			<min>1.0</min>
			<max>10.0</max>
		</option>
		<option name="layout" type="string">
			<_short>Layout</_short>
			<_long>Sets the position of the display.</_long>
			<default>default</default>
		</option>
		<option name="transform" type="string">
			<_short>Transform</_short>
			<_long>Sets the rotation for the display.</_long>
			<default>normal</default>
		</option>
	</object>
</wayfire>
```

Hopefully it's obvious how consumers like wcm could generate UI for this xml that would produce the config above. And in core, the result of parsing will be used as a template to be cloned into e.g. `core.output:WL-1` — so the types will be checked in the above config.

And here's the diff:

```diff
diff --git i/metadata/meson.build w/metadata/meson.build
index b34da6db..5a92a9c9 100644
--- i/metadata/meson.build
+++ w/metadata/meson.build
@@ -4,6 +4,7 @@ install_data('autostart.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('blur.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('command.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('core.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
+install_data('core.output.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('cube.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('decoration.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('expo.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
diff --git i/src/core/output-layout.cpp w/src/core/output-layout.cpp
index 6bb8cd48..3e67eca2 100644
--- i/src/core/output-layout.cpp
+++ w/src/core/output-layout.cpp
@@ -286,13 +286,17 @@ struct output_layout_output_t
     {
         std::string output_name = handle->name;
         auto& config = wf::get_core().config;
-        if (!config.get_section(output_name))
+        if (!config.get_section("core.output:" + output_name) && !config.get_section(output_name))
         {
             config.merge_section(
-                std::make_shared<wf::config::section_t>(output_name));
+                config.get_section("core.output")->clone_with_name("core.output:" + output_name));
         }
 
-        auto section = config.get_section(output_name);
+        auto section = config.get_section("core.output:" + output_name);
+        if (!section)
+            section = config.get_section(output_name);
+
+        // XXX: remove when removing support for legacy config (bare output_name)
         auto add_if_missing = [&] (std::string name, std::string defval)
         {
             if (!section->get_option_or(name))
```

With this example we can see that a type error in the config would be detected by the config parser:
```
EE 30-10-20 15:51:24.128 - [subprojects/wf-config/src/file.cpp:299] Error in file wayfire.ini:44, invalid option value!
```

instead of the output handling part of core:

```
EE 30-10-20 15:50:18.961 - [src/core/output-layout.cpp:500] Invalid scale for WL-1 in config: lol
```

so the `add_if_missing` stuff could be deleted after support for old-style compatibility is dropped.