### PR TITLE
Allow button bindings to be matched regardless of pressed modifier keys

### DIFF
--- a/include/wayfire/config/types.hpp
+++ b/include/wayfire/config/types.hpp
@@ -221,6 +221,10 @@ struct buttonbinding_t
     /** @return The button of the buttonbinding */
     uint32_t get_button() const;
 
+    /** Constant to represent that a binding should match any (or no)
+     *  pressed modifiers. Only used internally, not exposed to users. */
+    static constexpr uint32_t any_modifier = (uint32_t)-1;
+
   private:
     /** The modifier mask of this keybinding */
     uint32_t mod;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -514,6 +514,11 @@ std::string wf::option_type::to_string(
 
 bool wf::buttonbinding_t::operator ==(const buttonbinding_t& other) const
 {
+    if ((this->mod == any_modifier) || (other.mod == any_modifier))
+    {
+        return this->button == other.button;
+    }
+
     return this->mod == other.mod && this->button == other.button;
 }
 


### PR DESCRIPTION
This can be used internally to execute an action on a click regardless of the state of the modifiers.