### PR TITLE
dynamic lists

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -6,7 +6,8 @@ headers_config = [
 'wayfire/config/types.hpp',
 'wayfire/config/file.hpp',
 'wayfire/config/option.hpp',
-'wayfire/config/option-wrapper.hpp'
+'wayfire/config/option-wrapper.hpp',
+'wayfire/config/compound-option.hpp',
 ]
 
 headers_util = [

--- a/include/wayfire/config/compound-option.hpp
+++ b/include/wayfire/config/compound-option.hpp
@@ -2,7 +2,6 @@
 
 #include <wayfire/config/types.hpp>
 #include <wayfire/config/option.hpp>
-#include <wayfire/config/section.hpp>
 #include <wayfire/util/log.hpp>
 #include <vector>
 #include <map>
@@ -103,14 +102,6 @@ class compound_option_t : public option_base_t
      *   (key2, v12, v22)
      */
     compound_option_t(const std::string& name, entries_t&& entries);
-
-    /**
-     * Update the value of this option by reading options from the section.
-     * The format is as described in the constructor docstring.
-     *
-     * Note: options which have been created from XML are ignored.
-     */
-    void update_from_section(const std::shared_ptr<section_t>& section);
 
     /**
      * Parse the compound option with the given types.

--- a/include/wayfire/config/compound-option.hpp
+++ b/include/wayfire/config/compound-option.hpp
@@ -107,6 +107,8 @@ class compound_option_t : public option_base_t
     /**
      * Update the value of this option by reading options from the section.
      * The format is as described in the constructor docstring.
+     *
+     * Note: options which have been created from XML are ignored.
      */
     void update_from_section(const std::shared_ptr<section_t>& section);
 

--- a/include/wayfire/config/compound-option.hpp
+++ b/include/wayfire/config/compound-option.hpp
@@ -1,0 +1,222 @@
+#pragma once
+
+#include <wayfire/config/types.hpp>
+#include <wayfire/config/option.hpp>
+#include <wayfire/config/section.hpp>
+#include <wayfire/util/log.hpp>
+#include <vector>
+#include <map>
+#include <cassert>
+
+namespace wf
+{
+namespace config
+{
+template<class... Args>
+using compound_list_t =
+    std::vector<std::tuple<std::string, Args...>>;
+
+/**
+ * A base class containing information about an entry in a tuple.
+ */
+class compound_option_entry_base_t
+{
+  public:
+
+    virtual ~compound_option_entry_base_t() = default;
+
+    /** @return The prefix of the tuple entry. */
+    virtual std::string get_prefix() const
+    {
+        return prefix;
+    }
+
+    /**
+     * Try to parse the given value.
+     *
+     * @param update Whether to override the stored value.
+     */
+    virtual bool is_parsable(const std::string&) const = 0;
+
+    /** Clone this entry */
+    virtual compound_option_entry_base_t *clone() const = 0;
+
+  protected:
+    compound_option_entry_base_t() = default;
+    std::string prefix;
+};
+
+template<class Type>
+class compound_option_entry_t : public compound_option_entry_base_t
+{
+  public:
+    compound_option_entry_t(const std::string& prefix)
+    {
+        this->prefix = prefix;
+    }
+
+    compound_option_entry_base_t *clone() const override
+    {
+        return new compound_option_entry_t<Type>(this->get_prefix());
+    }
+
+    /**
+     * Try to parse the given value.
+     *
+     * @param update Whether to override the stored value.
+     */
+    bool is_parsable(const std::string& str) const override
+    {
+        return option_type::from_string<Type>(str).has_value();
+    }
+};
+
+/**
+ * Compound options are a special class of options which can hold multiple
+ * string-tagged tuples. They are constructed from multiple untyped options
+ * in the config file.
+ */
+
+class compound_option_t : public option_base_t
+{
+  public:
+    using entries_t = std::vector<std::unique_ptr<compound_option_entry_base_t>>;
+    /**
+     * Construct a new compound option, with the types given in the template
+     * arguments.
+     *
+     * @param name The name of the option.
+     * @param prefixes The prefixes used for grouping in the config file.
+     *   Example: Consider a compound option with type <int, double> and two
+     *   prefixes {"prefix1_", "prefix2_"}. In the config file, the options are:
+     *
+     *   prefix1_key1 = v11
+     *   prefix2_key1 = v21
+     *   prefix1_key2 = v12
+     *   prefix2_key2 = v22
+     *
+     *   Options are grouped by suffixes (key1 and key2), and the tuples then
+     *   are formed by taking the values of the options with each prefix.
+     *   So, the tuples contained in the compound option in the end are:
+     *
+     *   (key1, v11, v21)
+     *   (key2, v12, v22)
+     */
+    compound_option_t(const std::string& name, entries_t&& entries);
+
+    /**
+     * Update the value of this option by reading options from the section.
+     * The format is as described in the constructor docstring.
+     */
+    void update_from_section(const std::shared_ptr<section_t>& section);
+
+    /**
+     * Parse the compound option with the given types.
+     *
+     * Throws an exception in case of wrong template types.
+     */
+    template<class... Args>
+    compound_list_t<Args...> get_value() const
+    {
+        compound_list_t<Args...> result;
+        result.resize(value.size());
+        build_recursive<0, Args...>(result);
+        return result;
+    }
+
+    /**
+     * Set the value of the option.
+     *
+     * Throws an exception in case of wrong template types.
+     */
+    template<class... Args>
+    void set_value(const compound_list_t<Args...>& value)
+    {
+        assert(sizeof...(Args) == this->entries.size());
+        this->value.assign(value.size(), {});
+        push_recursive<0>(value);
+        notify_updated();
+    }
+
+    using stored_type_t = std::vector<std::vector<std::string>>;
+    /**
+     * Get the string data stored in the compound option.
+     */
+    stored_type_t get_value_untyped();
+
+    /**
+     * Set the data contained in the option, from a vector containing
+     * strings which describe the individual elements.
+     *
+     * @return True if the operation was successful.
+     */
+    bool set_value_untyped(stored_type_t value);
+
+    /**
+     * Get the type information about entries in the option.
+     */
+    const entries_t& get_entries() const;
+
+  private:
+    /**
+     * Current value stored in the option.
+     * The first element is the name of the tuple, followed by the string values
+     * of each element.
+     */
+    stored_type_t value;
+
+    /** Entry types with which the option was created. */
+    entries_t entries;
+
+    /**
+     * Set the n-th element in the result tuples by reading from the stored
+     * values in this option.
+     */
+    template<size_t n, class... Args>
+    void build_recursive(compound_list_t<Args...>& result) const
+    {
+        for (size_t i = 0; i < result.size(); i++)
+        {
+            using type_t = typename std::tuple_element<n,
+                std::tuple<std::string, Args...>>::type;
+
+            std::get<n>(result[i]) = option_type::from_string<type_t>(
+                this->value[i][n]).value();
+        }
+
+        // Recursively build the (N+1)'th entries
+        if constexpr (n < sizeof...(Args))
+        {
+            build_recursive<n + 1>(result);
+        }
+    }
+
+    template<size_t n, class... Args>
+    void push_recursive(const compound_list_t<Args...>& new_value)
+    {
+        for (size_t i = 0; i < new_value.size(); i++)
+        {
+            using type_t = typename std::tuple_element<n,
+                std::tuple<std::string, Args...>>::type;
+
+            this->value[i].push_back(option_type::to_string<type_t>(
+                std::get<n>(new_value[i])));
+        }
+
+        // Recursively build the (N+1)'th entries
+        if constexpr (n < sizeof...(Args))
+        {
+            push_recursive<n + 1>(new_value);
+        }
+    }
+
+  public: // Implementation of option_base_t
+    std::shared_ptr<option_base_t> clone_option() const override;
+    bool set_value_str(const std::string&) override;
+    void reset_to_default() override;
+    bool set_default_value_str(const std::string&) override;
+    std::string get_value_str() const override;
+    std::string get_default_value_str() const override;
+};
+}
+}

--- a/include/wayfire/config/option-wrapper.hpp
+++ b/include/wayfire/config/option-wrapper.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <stdexcept>
 #include <wayfire/config/option.hpp>
+#include <wayfire/config/compound-option.hpp>
 
 namespace wf
 {
@@ -28,6 +30,22 @@ option_sptr_t<T> create_option_string(const std::string& value)
 }
 
 /**
+ * A helper to check whether the given type is a specialization of std::vector
+ */
+template<class>
+struct is_std_vector : public std::false_type {};
+
+template<class V, class A>
+struct is_std_vector<std::vector<V, A>> : public std::true_type {};
+
+template<class... Args>
+void get_value_from_compound_option(
+    config::compound_option_t *opt, config::compound_list_t<Args...>& list)
+{
+    list = opt->get_value<Args...>();
+}
+
+/**
  * A simple wrapper around a config option.
  *
  * This is a base class. Each application which uses it needs to subclass it
@@ -36,6 +54,12 @@ option_sptr_t<T> create_option_string(const std::string& value)
 template<class Type>
 class base_option_wrapper_t
 {
+  public:
+    using OptionType = std::conditional_t<
+        is_std_vector<Type>::value,
+        config::compound_option_t,
+        config::option_t<Type>>;
+
   public:
     base_option_wrapper_t(const base_option_wrapper_t& other) = delete;
     base_option_wrapper_t& operator =(
@@ -65,8 +89,7 @@ class base_option_wrapper_t
             throw std::runtime_error("No such option: " + std::string(name));
         }
 
-        raw_option = std::dynamic_pointer_cast<
-            wf::config::option_t<Type>>(untyped_option);
+        raw_option = std::dynamic_pointer_cast<OptionType>(untyped_option);
         if (raw_option == nullptr)
         {
             throw std::runtime_error("Bad option type: " + std::string(name));
@@ -86,10 +109,23 @@ class base_option_wrapper_t
     /** Implicitly convertible to the value of the option */
     operator Type() const
     {
-        return raw_option->get_value();
+        return this->value();
     }
 
-    operator option_sptr_t<Type>() const
+    Type value() const
+    {
+        if constexpr (is_std_vector<Type>::value)
+        {
+            Type list;
+            get_value_from_compound_option(this->raw_option.get(), list);
+            return list;
+        } else
+        {
+            return raw_option->get_value();
+        }
+    }
+
+    operator std::shared_ptr<OptionType>() const
     {
         return raw_option;
     }
@@ -105,7 +141,7 @@ class base_option_wrapper_t
     wf::config::option_base_t::updated_callback_t option_update_listener;
 
     /** The actual option wrapped by the option wrapper */
-    option_sptr_t<Type> raw_option;
+    std::shared_ptr<OptionType> raw_option;
 
     /**
      * Initialize the option wrapper.

--- a/include/wayfire/config/option.hpp
+++ b/include/wayfire/config/option.hpp
@@ -69,15 +69,31 @@ class option_base_t
      */
     void rem_updated_handler(updated_callback_t *callback);
 
+    /**
+     * Set the lock status of an option, this is reference-counted.
+     *
+     * An option is unlocked by default. When an option is locked, the option
+     * should not be modified by any config backend (for ex. when reading from
+     * a file).
+     *
+     * Note that changing the value of the option manually still works.
+     */
+    void set_locked(bool locked = true);
+
+    /**
+     * Get the current locked status.
+     */
+    bool is_locked() const;
+
+    struct impl;
+    std::unique_ptr<impl> priv;
+
   protected:
     /** Construct a new option with the given name. */
     option_base_t(const std::string& name);
 
     /** Notify all watchers */
     void notify_updated() const;
-
-    struct impl;
-    std::unique_ptr<impl> priv;
 };
 
 /**

--- a/include/wayfire/config/option.hpp
+++ b/include/wayfire/config/option.hpp
@@ -94,6 +94,9 @@ class option_base_t
 
     /** Notify all watchers */
     void notify_updated() const;
+
+    /** Initialize a cloned version of this option. */
+    void init_clone(option_base_t& clone) const;
 };
 
 /**
@@ -191,6 +194,7 @@ class option_t : public option_base_t,
             result->maximum = this->maximum;
         }
 
+        init_clone(*result);
         return result;
     }
 

--- a/include/wayfire/config/section.hpp
+++ b/include/wayfire/config/section.hpp
@@ -62,7 +62,6 @@ class section_t
      */
     void unregister_option(std::shared_ptr<option_base_t> option);
 
-  private:
     struct impl;
     std::unique_ptr<impl> priv;
 };

--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ sources = [
 'src/config-manager.cpp',
 'src/file.cpp',
 'src/duration.cpp',
+'src/compound-option.cpp',
 ]
 
 wfconfig_inc = include_directories('include')

--- a/src/compound-option.cpp
+++ b/src/compound-option.cpp
@@ -1,4 +1,5 @@
 #include <wayfire/config/compound-option.hpp>
+#include <wayfire/config/xml.hpp>
 
 using namespace wf::config;
 
@@ -33,6 +34,11 @@ void compound_option_t::update_from_section(
         const auto& prefix = entries[n]->get_prefix();
         for (auto& opt : options)
         {
+            if (xml::get_option_xml_node(opt))
+            {
+                continue;
+            }
+
             if (begins_with(opt->get_name(), prefix))
             {
                 // We have found a match.

--- a/src/compound-option.cpp
+++ b/src/compound-option.cpp
@@ -1,0 +1,164 @@
+#include <wayfire/config/compound-option.hpp>
+
+using namespace wf::config;
+
+static bool begins_with(const std::string& a, const std::string& b)
+{
+    return a.substr(0, b.size()) == b;
+}
+
+compound_option_t::compound_option_t(const std::string& name,
+    entries_t&& entries) : option_base_t(name)
+{
+    this->entries = std::move(entries);
+}
+
+void compound_option_t::update_from_section(
+    const std::shared_ptr<section_t>& section)
+{
+    auto options = section->get_registered_options();
+    std::vector<std::vector<std::string>> new_value;
+
+    struct tuple_in_construction_t
+    {
+        // How many of the tuple elements were initialized
+        size_t initialized = 0;
+        std::vector<std::string> values;
+    };
+
+    std::map<std::string, std::vector<std::string>> new_values;
+
+    for (size_t n = 0; n < entries.size(); n++)
+    {
+        const auto& prefix = entries[n]->get_prefix();
+        for (auto& opt : options)
+        {
+            if (begins_with(opt->get_name(), prefix))
+            {
+                // We have found a match.
+                // Find the suffix we should store values in.
+                std::string suffix = opt->get_name().substr(prefix.size());
+                if (!new_values.count(suffix) && (n > 0))
+                {
+                    // Skip entries which did not have their first value set,
+                    // because these will not be fully constructed in the end.
+                    continue;
+                }
+
+                auto& tuple = new_values[suffix];
+
+                // Parse the value from the option, with the n-th type.
+                if (!entries[n]->is_parsable(opt->get_value_str()))
+                {
+                    LOGE("Failed parsing option ",
+                        section->get_name() + "/" + opt->get_name(),
+                        " as part of the list option ",
+                        section->get_name() + "/" + this->get_name());
+                    new_values.erase(suffix);
+                    continue;
+                }
+
+                if (n == 0)
+                {
+                    // Push the suffix first
+                    tuple.push_back(suffix);
+                }
+
+                // Update the Nth entry in the tuple (+1 because the first entry
+                // is the amount of initialized entries).
+                tuple.push_back(opt->get_value_str());
+            }
+        }
+    }
+
+    this->value.clear();
+    for (auto& e : new_values)
+    {
+        // Ignore entires which do not have all entries set
+        if (e.second.size() != entries.size() + 1)
+        {
+            continue;
+        }
+
+        this->value.push_back(std::move(e.second));
+    }
+
+    notify_updated();
+}
+
+compound_option_t::stored_type_t compound_option_t::get_value_untyped()
+{
+    return this->value;
+}
+
+bool compound_option_t::set_value_untyped(stored_type_t value)
+{
+    for (auto& e : value)
+    {
+        if (e.size() != this->entries.size() + 1)
+        {
+            return false;
+        }
+
+        for (size_t i = 1; i <= this->entries.size(); i++)
+        {
+            if (!entries[i - 1]->is_parsable(e[i]))
+            {
+                return false;
+            }
+        }
+    }
+
+    this->value = value;
+    notify_updated();
+    return true;
+}
+
+const compound_option_t::entries_t& compound_option_t::get_entries() const
+{
+    return this->entries;
+}
+
+/* --------------------------- option_base_t impl --------------------------- */
+std::shared_ptr<option_base_t> compound_option_t::clone_option() const
+{
+    entries_t cloned;
+    for (auto& e : this->entries)
+    {
+        cloned.push_back(
+            std::unique_ptr<compound_option_entry_base_t>(e->clone()));
+    }
+
+    auto result = std::make_shared<compound_option_t>(get_name(), std::move(cloned));
+    result->value = this->value;
+    return result;
+}
+
+bool wf::config::compound_option_t::set_value_str(const std::string&)
+{
+    // XXX: not supported yet
+    return false;
+}
+
+void wf::config::compound_option_t::reset_to_default()
+{
+    this->value.clear();
+}
+
+bool wf::config::compound_option_t::set_default_value_str(const std::string&)
+{
+    // XXX: not supported yet
+    return false;
+}
+
+std::string wf::config::compound_option_t::get_value_str() const
+{
+    // XXX: not supported yet
+    return "";
+}
+
+std::string wf::config::compound_option_t::get_default_value_str() const
+{
+    // XXX: not supported yet
+    return "";
+}

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -352,7 +352,8 @@ void wf::config::load_configuration_options_from_string(
     {
         for (auto opt : section->get_registered_options())
         {
-            if (!reloaded.count(opt) && !opt->is_locked())
+            opt->priv->option_in_config_file = (reloaded.count(opt) > 0);
+            if (!opt->priv->option_in_config_file && !opt->is_locked())
             {
                 opt->reset_to_default();
             }
@@ -368,7 +369,7 @@ void wf::config::load_configuration_options_from_string(
             auto as_compound = std::dynamic_pointer_cast<compound_option_t>(opt);
             if (as_compound)
             {
-                as_compound->update_from_section(section);
+                update_compound_from_section(*as_compound, section);
             }
         }
     }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1,3 +1,4 @@
+#include <wayfire/config/compound-option.hpp>
 #include <wayfire/config/file.hpp>
 #include <wayfire/config/types.hpp>
 #include <wayfire/config/xml.hpp>
@@ -334,6 +335,18 @@ void wf::config::load_configuration_options_from_string(
 
           default:
             break;
+        }
+    }
+
+    for (auto section : config.get_all_sections())
+    {
+        for (auto opt : section->get_registered_options())
+        {
+            auto as_compound = std::dynamic_pointer_cast<compound_option_t>(opt);
+            if (as_compound)
+            {
+                as_compound->update_from_section(section);
+            }
         }
     }
 }

--- a/src/option-impl.hpp
+++ b/src/option-impl.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <wayfire/config/compound-option.hpp>
+#include <wayfire/config/section.hpp>
+#include <libxml/tree.h>
+#include <stdint.h>
+
+struct wf::config::option_base_t::impl
+{
+    std::string name;
+    std::vector<updated_callback_t*> updated_handlers;
+
+    // Number of times the option has been locked
+    int32_t lock_count = 0;
+
+    // Associated XML node
+    xmlNode *xml;
+
+    // Is option in config file?
+    bool option_in_config_file = false;
+};
+
+namespace wf
+{
+namespace config
+{
+/**
+ * Update the value of a compound option option by reading options from the section.
+ * The format is as described in the compound option constructor docstring.
+ *
+ * Note: options which have been created from XML are ignored, and only
+ * options which have been created from parsing a string/file with wf-config
+ * are taken into account.
+ */
+void update_compound_from_section(compound_option_t& option,
+    const std::shared_ptr<section_t>& section);
+}
+}

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -54,3 +54,9 @@ bool wf::config::option_base_t::is_locked() const
 {
     return this->priv->lock_count > 0;
 }
+
+void wf::config::option_base_t::init_clone(option_base_t& other) const
+{
+    other.priv->xml  = this->priv->xml;
+    other.priv->name = this->priv->name;
+}

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -2,11 +2,8 @@
 #include <algorithm>
 #include <vector>
 
-struct wf::config::option_base_t::impl
-{
-    std::string name;
-    std::vector<updated_callback_t*> updated_handlers;
-};
+#include "option-impl.hpp"
+#include "wayfire/util/log.hpp"
 
 std::string wf::config::option_base_t::get_name() const
 {
@@ -42,4 +39,18 @@ void wf::config::option_base_t::notify_updated() const
     {
         (*call)();
     }
+}
+
+void wf::config::option_base_t::set_locked(bool locked)
+{
+    this->priv->lock_count += (locked ? 1 : -1);
+    if (priv->lock_count < 0)
+    {
+        LOGE("Lock counter for option ", this->get_name(), " dropped below zero!");
+    }
+}
+
+bool wf::config::option_base_t::is_locked() const
+{
+    return this->priv->lock_count > 0;
 }

--- a/src/section-impl.hpp
+++ b/src/section-impl.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <wayfire/config/section.hpp>
+#include <libxml/tree.h>
+#include <map>
+
+struct wf::config::section_t::impl
+{
+  public:
+    std::map<std::string, std::shared_ptr<option_base_t>> options;
+    std::string name;
+
+    // Associated XML node
+    xmlNode *xml = NULL;
+};

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -1,13 +1,5 @@
-#include <wayfire/config/section.hpp>
 #include <stdexcept>
-#include <map>
-
-struct wf::config::section_t::impl
-{
-  public:
-    std::map<std::string, std::shared_ptr<option_base_t>> options;
-    std::string name;
-};
+#include "section-impl.hpp"
 
 wf::config::section_t::section_t(const std::string& name)
 {
@@ -31,6 +23,7 @@ std::shared_ptr<wf::config::section_t> wf::config::section_t::clone_with_name(
         result->register_new_option(option.second->clone_option());
     }
 
+    result->priv->xml = this->priv->xml;
     return result;
 }
 

--- a/test/dummy.ini
+++ b/test/dummy.ini
@@ -3,5 +3,7 @@ option1 = 4
 option2 = 45 \# 46 \\
 
 [section2]
+bey_k1 = 1.200000
+hey_k1 = 1
 option1 = 4.250000
 

--- a/test/file_test.cpp
+++ b/test/file_test.cpp
@@ -94,6 +94,34 @@ TEST_CASE("wf::config::load_configuration_options_from_string")
     EXPECT_LINE(log, "Error in file test:21");
 }
 
+const std::string minimal_config_with_opt =
+    R"(
+[section]
+option = value
+)";
+
+TEST_CASE("wf::config::load_configuration_options_from_string - lock & reload")
+{
+    using namespace wf;
+    using namespace wf::config;
+
+    config_manager_t cfg;
+    load_configuration_options_from_string(cfg, minimal_config_with_opt);
+
+    SUBCASE("locked")
+    {
+        cfg.get_option("section/option")->set_locked();
+        load_configuration_options_from_string(cfg, "");
+        CHECK(cfg.get_option("section/option")->get_value_str() == "value");
+    }
+
+    SUBCASE("unlocked")
+    {
+        load_configuration_options_from_string(cfg, "");
+        CHECK(cfg.get_option("section/option")->get_value_str() == "");
+    }
+}
+
 wf::config::config_manager_t build_simple_config()
 {
     using namespace wf;

--- a/test/file_test.cpp
+++ b/test/file_test.cpp
@@ -107,6 +107,13 @@ wf::config::config_manager_t build_simple_config()
     section2->register_new_option(std::make_shared<option_t<double>>("option1",
         4.25));
 
+    compound_option_t::entries_t entries;
+    entries.push_back(std::make_unique<compound_option_entry_t<int>>("hey_"));
+    entries.push_back(std::make_unique<compound_option_entry_t<double>>("bey_"));
+    auto opt = new compound_option_t{"option_list", std::move(entries)};
+    opt->set_value(compound_list_t<int, double>{{"k1", 1, 1.2}});
+    section2->register_new_option(std::shared_ptr<compound_option_t>(opt));
+
     config_manager_t config;
     config.merge_section(section1);
     config.merge_section(section2);
@@ -120,6 +127,8 @@ option1 = 4
 option2 = 45 \# 46 \\
 
 [section2]
+bey_k1 = 1.200000
+hey_k1 = 1
 option1 = 4.250000
 
 )";

--- a/test/meson.build
+++ b/test/meson.build
@@ -51,7 +51,7 @@ test('ConfigManager test', config_manager_test)
 file_parse_test = executable(
     'file_test',
     'file_test.cpp',
-    dependencies: wfconfig,
+    dependencies: [wfconfig, libxml2],
     install: false,
     cpp_args: '-DTEST_SOURCE="' + meson.current_source_dir() + '"')
 test('File parsing test', file_parse_test)

--- a/test/meson.build
+++ b/test/meson.build
@@ -15,7 +15,7 @@ test('OptionBase test', option_base_test)
 option_test = executable(
     'option_test',
     'option_test.cpp',
-    dependencies: wfconfig,
+    dependencies: [wfconfig, libxml2],
     install: false)
 test('Option test', option_test)
 
@@ -29,7 +29,7 @@ test('Option wrapper test', option_wrapper_test)
 section_test = executable(
     'section_test',
     'section_test.cpp',
-    dependencies: wfconfig,
+    dependencies: [wfconfig, libxml2],
     install: false)
 test('Section test', section_test)
 

--- a/test/option_base_test.cpp
+++ b/test/option_base_test.cpp
@@ -76,4 +76,12 @@ TEST_CASE("wf::option_base_t")
     option.notify_updated();
     CHECK(callback_called == 3);
     CHECK(callback2_called == 2);
+
+    option.set_locked();
+    CHECK(option.is_locked());
+    option.set_locked();
+    option.set_locked(false);
+    CHECK(option.is_locked());
+    option.set_locked(false);
+    CHECK(option.is_locked() == false);
 }

--- a/test/option_test.cpp
+++ b/test/option_test.cpp
@@ -6,6 +6,7 @@
 #include <wayfire/config/types.hpp>
 #include <linux/input-event-codes.h>
 #include <algorithm>
+#include "../src/option-impl.hpp"
 
 /**
  * A struct to check whether the maximum and minimum methods are enabled on the
@@ -89,8 +90,10 @@ TEST_CASE("wf::config::option_t<unboundable>")
         clone_callback_called++;
     };
     opt.add_updated_handler(&callback);
+    opt.priv->xml = (xmlNode*)0x123;
     auto clone = std::static_pointer_cast<option_t<wf::keybinding_t>>(
         opt.clone_option());
+    CHECK(clone->priv->xml == (xmlNode*)0x123);
     CHECK(clone->get_name() == opt.get_name());
     CHECK(clone->get_default_value() == opt.get_default_value());
     CHECK(clone->get_value() == opt.get_value());

--- a/test/option_test.cpp
+++ b/test/option_test.cpp
@@ -206,6 +206,13 @@ TEST_CASE("compound options")
     CHECK(std::get<1>(values[1]) == -12);
     CHECK(std::get<2>(values[1]) == 3.1415);
 
+    std::vector<std::vector<std::string>> untyped_values = {
+        {"k1", "1", "1.200000"},
+        {"k2", "-12", "3.141500"},
+    };
+
+    CHECK(opt.get_value_untyped() == untyped_values);
+
     compound_list_t<int, double> v = {
         {"k3", 1, 1.23}
     };

--- a/test/option_test.cpp
+++ b/test/option_test.cpp
@@ -201,10 +201,17 @@ TEST_CASE("compound options")
     // Options which don't match anything
     section->register_new_option(std::make_shared<option_t<double>>("hallo", 3.5));
 
-    opt.update_from_section(section);
+    // Mark all options as coming from the config file, otherwise, they wont' be
+    // parsed
+    for (auto& opt : section->get_registered_options())
+    {
+        opt->priv->option_in_config_file = true;
+    }
+
+    update_compound_from_section(opt, section);
     auto values = opt.get_value<int, double>();
 
-    CHECK(values.size() == 2);
+    REQUIRE(values.size() == 2);
     std::sort(values.begin(), values.end());
 
     CHECK(std::get<0>(values[0]) == "k1");

--- a/test/option_test.cpp
+++ b/test/option_test.cpp
@@ -187,10 +187,16 @@ TEST_CASE("compound options")
         3.1415));
 
     // Not fully specified pairs
-    section->register_new_option(std::make_shared<option_t<double>>("hey_k3", 3));
-    section->register_new_option(std::make_shared<option_t<std::string>>("bey_k3",
+    section->register_new_option(std::make_shared<option_t<int>>("hey_k3", 3));
+    // One of the values is a regular option with an associated XML tag, and
+    // needs to be skipped
+    auto xml_opt = std::make_shared<option_t<double>>("bey_k3", 5.5);
+    xml_opt->priv->xml = (xmlNode*)0x123;
+    section->register_new_option(xml_opt);
+
+    section->register_new_option(std::make_shared<option_t<std::string>>("bey_k4",
         "invalid value"));
-    section->register_new_option(std::make_shared<option_t<double>>("bey_k4", 3.5));
+    section->register_new_option(std::make_shared<option_t<double>>("bey_k5", 3.5));
 
     // Options which don't match anything
     section->register_new_option(std::make_shared<option_t<double>>("hallo", 3.5));

--- a/test/option_wrapper_test.cpp
+++ b/test/option_wrapper_test.cpp
@@ -33,12 +33,27 @@ TEST_CASE("wf::base_option_wrapper_t")
 
     auto section = std::make_shared<section_t>("Test");
     auto opt     = std::make_shared<option_t<int>>("Option1", 5);
+
+    compound_option_t::entries_t entries;
+    entries.push_back(std::make_unique<compound_option_entry_t<int>>("hey_"));
+    entries.push_back(std::make_unique<compound_option_entry_t<double>>("bey_"));
+
+    auto coptr = new compound_option_t{"Option2", std::move(entries)};
+    auto copt  = std::shared_ptr<option_base_t>(coptr);
+
     section->register_new_option(opt);
+    section->register_new_option(copt);
     ::config.merge_section(section);
 
     wrapper_t<int> wrapper{"Test/Option1"};
     CHECK((option_sptr_t<int>)wrapper == opt);
     CHECK(wrapper == 5);
+
+    wrapper_t<compound_list_t<int, double>> wrapper2{"Test/Option2"};
+    CHECK((std::shared_ptr<compound_option_t>)wrapper2 == copt);
+    bool value_in_compound_list_is_ok =
+        (wrapper2.value() == compound_list_t<int, double>{});
+    CHECK(value_in_compound_list_is_ok);
 
     bool updated = false;
     wrapper.set_callback([&] ()

--- a/test/section_test.cpp
+++ b/test/section_test.cpp
@@ -3,6 +3,7 @@
 
 #include <wayfire/config/section.hpp>
 #include <wayfire/config/types.hpp>
+#include "../src/section-impl.hpp"
 
 TEST_CASE("wf::config::section_t")
 {
@@ -36,8 +37,10 @@ TEST_CASE("wf::config::section_t")
     CHECK(section.get_registered_options().empty());
 
     section.register_new_option(intopt);
+    section.priv->xml = (xmlNode*)0x123;
     auto clone = section.clone_with_name("Cloned_Section");
     CHECK(clone->get_name() == "Cloned_Section");
+    CHECK(clone->priv->xml == (xmlNode*)0x123);
     CHECK(clone->get_option_or("IntOption") != intopt);
     CHECK(clone->get_option_or("IntOption")->get_name() == intopt->get_name());
     CHECK(clone->get_option_or(


### PR DESCRIPTION
Opening this to track progress of dynamic lists in wf-config.

Roadmap:

- [x] Implement compound list option type
- [x] Add support for compound options in `section_t`
- [x] Add support for compound options in XML parser
- [x] Parse compound options when reloading config file
- [x] Save compound options when writing to file

Fixes #26