### PR TITLE
Support multiple object sections per XML file.

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -523,7 +523,7 @@ void wf::config::save_configuration_to_file(
 }
 
 static void process_xml_file(wf::config::config_manager_t& manager,
-    const std::string &filename)
+    const std::string & filename)
 {
     LOGI("Reading XML configuration options from file ", filename);
 
@@ -549,7 +549,7 @@ static void process_xml_file(wf::config::config_manager_t& manager,
     {
         if ((section->type == XML_ELEMENT_NODE) &&
             (((const char*)section->name == (std::string)"plugin") ||
-                ((const char*)section->name == (std::string)"object")))
+             ((const char*)section->name == (std::string)"object")))
         {
             manager.merge_section(
                 wf::config::xml::create_section_from_xml_node(section));


### PR DESCRIPTION
The current config only looks at the first <object></object> section and discards the rest.

This patch allows for more than one such sections per file. This comes in handy if using a plugin that groups things in profiles, for example. There's also the "input-device:..." settings which can be applied system-wide for instance on a custom piece of hardware. And best of all, no extra code is needed: just making the loop around create_section_from_xml_node.

I do notice the original code doesn't free the doc at the end (if successful), created here:
`auto doc = xmlParseFile(file.c_str());`
Is there a reason for this? Maybe worth mentioning it in a comment.