### PR TITLE
Fix locale issues

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('tests', type: 'feature', value: 'auto', description: 'Enable unit tests')
+option('locale_test', type : 'boolean', value : false, description: 'Test number to string conversions with de_DE locale (must be installed)')

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -34,6 +34,7 @@ template<>
 stdx::optional<int> wf::option_type::from_string(const std::string& value)
 {
     std::istringstream in{value};
+    in.imbue(std::locale::classic());
     int result;
     in >> result;
 
@@ -49,11 +50,10 @@ stdx::optional<int> wf::option_type::from_string(const std::string& value)
 template<>
 stdx::optional<double> wf::option_type::from_string(const std::string& value)
 {
-    auto old = std::locale::global(std::locale::classic());
     std::istringstream in{value};
+    in.imbue(std::locale::classic());
     double result;
     in >> result;
-    std::locale::global(old);
 
     if (!in.eof() || in.fail() || value.empty())
     {
@@ -131,16 +131,14 @@ static stdx::optional<wf::color_t> try_parse_rgba(const std::string& value)
 {
     wf::color_t parsed = {0, 0, 0, 0};
     std::stringstream ss(value);
+    ss.imbue(std::locale::classic());
 
-    auto old = std::locale::global(std::locale::classic());
     bool valid_color =
         (bool)(ss >> parsed.r >> parsed.g >> parsed.b >> parsed.a);
 
     /* Check nothing else after that */
     std::string dummy;
     valid_color &= !(bool)(ss >> dummy);
-
-    std::locale::global(old);
 
     return valid_color ? parsed : stdx::optional<wf::color_t>{};
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -37,7 +37,7 @@ stdx::optional<int> wf::option_type::from_string(const std::string& value)
     int result;
     in >> result;
 
-    if (value != std::to_string(result))
+    if (value != wf::option_type::to_string(result))
     {
         return {};
     }
@@ -81,14 +81,20 @@ template<>
 std::string wf::option_type::to_string(
     const int& value)
 {
-    return std::to_string(value);
+    std::ostringstream s;
+    s.imbue(std::locale::classic());
+    s << value;
+    return s.str();
 }
 
 template<>
 std::string wf::option_type::to_string(
     const double& value)
 {
-    return std::to_string(value);
+    std::ostringstream s;
+    s.imbue(std::locale::classic());
+    s << std::fixed << value;
+    return s.str();
 }
 
 template<>
@@ -717,7 +723,7 @@ std::string wf::option_type::to_string(const touchgesture_t& value)
         break;
     }
 
-    result += std::to_string(value.get_finger_count());
+    result += wf::option_type::to_string(value.get_finger_count());
     return result;
 }
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -70,3 +70,13 @@ duration_test = executable(
     dependencies: [wfconfig, doctest],
     install: false)
 test('Duration test', duration_test)
+
+number_locale_test = executable(
+    'number_locale_test',
+    'number_locale_test.cpp',
+    dependencies: [wfconfig, doctest],
+    install: false)
+# enable locale test only on request
+if get_option('locale_test')
+  test('Number locale test', number_locale_test)
+endif

--- a/test/number_locale_test.cpp
+++ b/test/number_locale_test.cpp
@@ -18,7 +18,6 @@ void setup_test_locale()
     // requires glibc-langpack-de
     // changes std::to_string output
     std::setlocale(LC_NUMERIC, "fr_FR.UTF-8");
-
 }
 
 TEST_CASE("wf::option_type::to_string<double>")

--- a/test/number_locale_test.cpp
+++ b/test/number_locale_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("wf::option_type::to_string<double>")
     setup_test_locale();
 
     std::string str = wf::option_type::to_string(3.14);
-    CHECK(str.compare(0, 3, "3.14") == 0);
+    CHECK(str == "3.140000");
     CHECK(wf::option_type::to_string(3140) == "3140");
 }
 
@@ -74,9 +74,9 @@ TEST_CASE("wf::int_wrapper_t locale")
     int32_t max = std::numeric_limits<int32_t>::max();
     int32_t min = std::numeric_limits<int32_t>::min();
     setup_test_locale();
-    CHECK(from_string<int>(std::to_string(max)).value() == max);
+    CHECK(from_string<int>(wf::option_type::to_string(max)).value() == max);
     setup_test_locale();
-    CHECK(from_string<int>(std::to_string(min)).value() == min);
+    CHECK(from_string<int>(wf::option_type::to_string(min)).value() == min);
 
     setup_test_locale();
     CHECK(!from_string<int>("1e4"));
@@ -102,9 +102,9 @@ TEST_CASE("wf::double_wrapper_t locale")
     double min = std::numeric_limits<double>::min();
 
     setup_test_locale();
-    CHECK(from_string<double>(std::to_string(max)).value() == doctest::Approx(max));
+    CHECK(from_string<double>(wf::option_type::to_string(max)).value() == doctest::Approx(max));
     setup_test_locale();
-    CHECK(from_string<double>(std::to_string(min)).value() == doctest::Approx(min));
+    CHECK(from_string<double>(wf::option_type::to_string(min)).value() == doctest::Approx(min));
 
     setup_test_locale();
     CHECK(!from_string<double>("1u4"));

--- a/test/number_locale_test.cpp
+++ b/test/number_locale_test.cpp
@@ -1,0 +1,155 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/config/types.hpp>
+#include <linux/input-event-codes.h>
+#include <limits>
+
+#include <locale>
+
+#define WF_CONFIG_DOUBLE_EPS 0.01
+
+using namespace wf;
+using namespace wf::option_type;
+
+
+void setup_test_locale()
+{
+    // requires glibc-langpack-de
+    // changes std::to_string output
+    std::setlocale(LC_NUMERIC, "fr_FR.UTF-8");
+
+}
+
+TEST_CASE("wf::option_type::to_string<double>")
+{
+    setup_test_locale();
+
+    std::string str = wf::option_type::to_string(3.14);
+    CHECK(str.compare(0, 3, "3.14") == 0);
+    CHECK(wf::option_type::to_string(3140) == "3140");
+}
+
+TEST_CASE("wf::bool_wrapper_t locale")
+{
+    setup_test_locale();
+
+    setup_test_locale();
+    CHECK(from_string<bool>("True").value());
+    setup_test_locale();
+    CHECK(from_string<bool>("true").value());
+    setup_test_locale();
+    CHECK(from_string<bool>("1").value());
+
+    setup_test_locale();
+    CHECK(from_string<bool>("False").value() == false);
+    setup_test_locale();
+    CHECK(from_string<bool>("false").value() == false);
+    setup_test_locale();
+    CHECK(from_string<bool>("0").value() == false);
+    setup_test_locale();
+
+    setup_test_locale();
+    CHECK(!from_string<bool>("vrai"));
+    setup_test_locale();
+    CHECK(!from_string<bool>("faux"));
+    setup_test_locale();
+
+    setup_test_locale();
+    CHECK(from_string<bool>(to_string<bool>(true)).value());
+    setup_test_locale();
+    CHECK(from_string<bool>(to_string<bool>(false)).value() == false);
+    setup_test_locale();
+}
+
+TEST_CASE("wf::int_wrapper_t locale")
+{
+    setup_test_locale();
+
+    setup_test_locale();
+    CHECK(from_string<int>("1456").value() == 1456);
+    setup_test_locale();
+    CHECK(from_string<int>("-89").value() == -89);
+
+    int32_t max = std::numeric_limits<int32_t>::max();
+    int32_t min = std::numeric_limits<int32_t>::min();
+    setup_test_locale();
+    CHECK(from_string<int>(std::to_string(max)).value() == max);
+    setup_test_locale();
+    CHECK(from_string<int>(std::to_string(min)).value() == min);
+
+    setup_test_locale();
+    CHECK(!from_string<int>("1e4"));
+    setup_test_locale();
+    CHECK(!from_string<int>(""));
+    setup_test_locale();
+    CHECK(!from_string<int>("1234567890000"));
+
+    setup_test_locale();
+    CHECK(from_string<int>(to_string<int>(456)).value() == 456);
+    setup_test_locale();
+    CHECK(from_string<int>(to_string<int>(0)).value() == 0);
+}
+
+TEST_CASE("wf::double_wrapper_t locale")
+{
+    setup_test_locale();
+    CHECK(from_string<double>("0.378000").value() == doctest::Approx(0.378));
+    setup_test_locale();
+    CHECK(from_string<double>("-89.1847").value() == doctest::Approx(-89.1847));
+
+    double max = std::numeric_limits<double>::max();
+    double min = std::numeric_limits<double>::min();
+
+    setup_test_locale();
+    CHECK(from_string<double>(std::to_string(max)).value() == doctest::Approx(max));
+    setup_test_locale();
+    CHECK(from_string<double>(std::to_string(min)).value() == doctest::Approx(min));
+
+    setup_test_locale();
+    CHECK(!from_string<double>("1u4"));
+    setup_test_locale();
+    CHECK(!from_string<double>(""));
+    setup_test_locale();
+    CHECK(!from_string<double>("abc"));
+
+    setup_test_locale();
+    CHECK(from_string<double>(to_string<double>(-4.56)).value() ==
+        doctest::Approx(-4.56));
+    setup_test_locale();
+    CHECK(from_string<double>(to_string<double>(0.0)).value() == doctest::Approx(0));
+}
+
+/* Test that various wf::color_t constructors work */
+TEST_CASE("wf::color_t")
+{
+    using namespace wf;
+    using namespace option_type;
+
+    setup_test_locale();
+
+    setup_test_locale();
+    CHECK(!from_string<color_t>("#FFF"));
+    setup_test_locale();
+    CHECK(!from_string<color_t>("0C1A"));
+    setup_test_locale();
+    CHECK(!from_string<color_t>(""));
+    setup_test_locale();
+    CHECK(!from_string<color_t>("#ZYXUIOPQ"));
+    setup_test_locale();
+    CHECK(!from_string<color_t>("#AUIO")); // invalid color
+    setup_test_locale();
+    CHECK(!from_string<color_t>("1.0 0.5 0.5 1.0 1.0")); // invalid color
+    setup_test_locale();
+    CHECK(!from_string<color_t>("1.0 0.5 0.5 1.0 asdf")); // invalid color
+    setup_test_locale();
+    CHECK(!from_string<color_t>("1.0 0.5")); // invalid color
+
+    setup_test_locale();
+    CHECK(to_string<color_t>(color_t{0, 0, 0, 0}) == "#00000000");
+    setup_test_locale();
+    CHECK(to_string<color_t>(color_t{0.4, 0.8, 0.3686274,
+        0.9686274}) == "#66CC5EF7");
+    setup_test_locale();
+    CHECK(to_string<color_t>(color_t{1, 1, 1, 1}) == "#FFFFFFFF");
+}


### PR DESCRIPTION
Should fix #46 

I added a test that checks whether the conversion to_string/from_string still work with a different locale (optional, because the locale files for de_DE must be installed)

The problem was `std::to_string`, which follows the C locale which the GUI in wcm might have changed. The global locale seemed very nondeterministic overall, e.g. I only had problems when wcm saved the config after disabling a plugin, not after changing a normal option. The code does not rely on global locale that much anymore now.