### PR TITLE
Add mode option to mirror

### DIFF
--- a/include/wayfire/config/types.hpp
+++ b/include/wayfire/config/types.hpp
@@ -517,6 +517,11 @@ struct mode_t
      */
     mode_t(const std::string& mirror_from);
 
+    /**
+     * Initialize a mirror mode with a custom mode on the output
+     */
+    mode_t(const std::string& mirror_from, int32_t width, int32_t height, int32_t refresh);
+
     /** @return The type of this mode. */
     mode_type_t get_type() const;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1044,6 +1044,18 @@ wf::output_config::mode_t::mode_t(const std::string& mirror_from)
     this->mirror_from = mirror_from;
 }
 
+/**
+ * Initialize a mirror mode with a display mode.
+ */
+wf::output_config::mode_t::mode_t(const std::string& mirror_from, int32_t width, int32_t height, int32_t refresh)
+{
+    this->type = MODE_MIRROR;
+    this->mirror_from = mirror_from;
+    this->width   = width;
+    this->height  = height;
+    this->refresh = refresh;
+}
+
 /** @return The type of this mode. */
 wf::output_config::mode_type_t wf::output_config::mode_t::get_type() const
 {
@@ -1108,29 +1120,26 @@ stdx::optional<wf::output_config::mode_t> wf::option_type::from_string(
         return wf::output_config::mode_t{true};
     }
 
+    std::string resolution,from;
+
     if (string.substr(0, 6) == "mirror")
     {
         std::stringstream ss(string);
-        std::string from, dummy;
         ss >> from; // the mirror word
-        if (!(ss >> from))
+        if (ss >> from)
         {
-            return {};
+            return wf::output_config::mode_t{from};
         }
 
-        // trailing garbage
-        if (ss >> dummy)
-        {
-            return {};
-        }
-
-        return wf::output_config::mode_t{from};
+        ss >> resolution;
     }
+
+    resolution = string;
 
     int w, h, rr = 0;
     char next;
 
-    int read = std::sscanf(string.c_str(), "%d x %d @ %d%c", &w, &h, &rr, &next);
+    int read = std::sscanf(resolution.c_str(), "%d x %d @ %d%c", &w, &h, &rr, &next);
     if ((read < 2) || (read > 3))
     {
         return {};
@@ -1147,7 +1156,11 @@ stdx::optional<wf::output_config::mode_t> wf::option_type::from_string(
         rr *= 1000;
     }
 
-    return wf::output_config::mode_t{w, h, rr};
+    if (from.empty()) {
+        return wf::output_config::mode_t{w, h, rr};
+    }
+
+    return wf::output_config::mode_t{from, w, h, rr};    
 }
 
 /** Represent the activator binding as a string. */

--- a/test/types_test.cpp
+++ b/test/types_test.cpp
@@ -437,6 +437,7 @@ TEST_CASE("wf::output_config::mode_t")
         "1920x1080@59",
         "1920x 1080 @ 59000",
         "mirror    eDP-1",
+        "mirror DP-1 1920x1080@60000",
     };
 
     std::vector<std::string> invalid = {


### PR DESCRIPTION
Adding the config option is step 1, I'll open another PR in the Wayfire branch which checks the option and sets the mode.

This is step 1, I'll also add a the a PR to the Wayfire branch which checks this.

This adds support for a config option like:

```
[option:DP-2]
mode = mirror DP-1 1920x1080@60000
```

## Reason

Currently Mirroring works like this: 

```
          case output_config::MODE_MIRROR:
            state.source = OUTPUT_IMAGE_SOURCE_MIRROR;
            state.mode   = select_default_mode();
            state.mirror_from = mode.get_mirror_from();
            break;
```

This sets the monitors default mode and mirrors another output. This can have side effects and unexpected behaviour when the mirrors resolution and refresh rate don't match the outputs.  For example, if you mirror a 60hz screen on a 144hz screen the frames don't sync up neatly and it looks strangely jerky, by forcing the output to 120hz or 60hz there are fewer display issues.

While we could just copy the source's mode here, we might try to copy a monitor that runs at 60hz to a monitor that runs at 59.9hz, not solving the problem. Rather than trying to guess at a best match, let's let the user decide.

My next PR is going to adjust the logic above to set the mode from the config if it's set, otherwise use the existing behaviour.