### PR TITLE
load_xml_files: handle DT_UNKNOWN

### DIFF
--- a/src/config-manager.cpp
+++ b/src/config-manager.cpp
@@ -47,8 +47,7 @@ std::shared_ptr<wf::config::section_t> wf::config::config_manager_t::get_section
     return nullptr;
 }
 
-std::vector<std::shared_ptr<wf::config::section_t>> wf::config::config_manager_t::
-get_all_sections() const
+std::vector<std::shared_ptr<wf::config::section_t>> wf::config::config_manager_t::get_all_sections() const
 {
     std::vector<std::shared_ptr<wf::config::section_t>> list;
     for (auto& section : this->priv->sections)

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -577,7 +577,7 @@ static wf::config::config_manager_t load_xml_files(
         struct dirent *entry;
         while ((entry = readdir(xmld)) != NULL)
         {
-            if ((entry->d_type != DT_LNK) && (entry->d_type != DT_REG))
+            if ((entry->d_type != DT_LNK) && (entry->d_type != DT_REG) && (entry->d_type != DT_UNKNOWN))
             {
                 continue;
             }

--- a/src/xml.cpp
+++ b/src/xml.cpp
@@ -196,8 +196,7 @@ std::shared_ptr<wf::config::option_base_t> parse_compound_option(xmlNodePtr node
     return std::shared_ptr<wf::config::option_base_t>(opt);
 }
 
-std::shared_ptr<wf::config::option_base_t> wf::config::xml::
-create_option_from_xml_node(xmlNodePtr node)
+std::shared_ptr<wf::config::option_base_t> wf::config::xml::create_option_from_xml_node(xmlNodePtr node)
 {
     if ((node->type != XML_ELEMENT_NODE) ||
         ((const char*)node->name != std::string{"option"}))


### PR DESCRIPTION
Some filesystems (like ext4 with missing journal, or XFS) don't support reading d_type from readdir(). Handle this case.