### PR TITLE
Fix build with gcc 14

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <cassert>
 #include <set>
+#include <algorithm>
 
 #include "option-impl.hpp"
 


### PR DESCRIPTION
Fix building with gcc 14 by adding `#include <algorithm>` to src/file.cpp

FAILED: libwf-config.so.0.9.0.p/src_file.cpp.o
ccache c++ -Ilibwf-config.so.0.9.0.p -I. -I.. -Iinclude -I../include -I/usr/include/libevdev-1.0 -I/usr/include/libxml2 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++17 -O0 -g -Wno-deprecated-declarations -fPIC -MD -MQ libwf-config.so.0.9.0.p/src_file.cpp.o -MF libwf-config.so.0.9.0.p/src_file.cpp.o.d -o libwf-config.so.0.9.0.p/src_file.cpp.o -c ../src/file.cpp ../src/file.cpp: In lambda function: ../src/file.cpp:419:25: error: ‘any_of’ is not a member of ‘std’
  419 |             return std::any_of(
      |                         ^~~~~~