### PR TITLE
add configurable animations

### DIFF
--- a/include/wayfire/util/duration.hpp
+++ b/include/wayfire/util/duration.hpp
@@ -1,5 +1,8 @@
 #pragma once
 #include <wayfire/config/option.hpp>
+#include <wayfire/config/option-types.hpp>
+#include <functional>
+
 
 namespace wf
 {
@@ -21,7 +24,37 @@ extern smooth_function circle;
 /** "sigmoid" smoothing function, i.e x -> 1.0 / (1 + exp(-12 * x + 6)) */
 extern smooth_function sigmoid;
 }
+}
 
+struct animation_description_t
+{
+    int length_ms;
+    animation::smoothing::smooth_function easing;
+    std::string easing_name;
+
+    bool operator ==(const animation_description_t& other) const
+    {
+        return (length_ms == other.length_ms) && (easing_name == other.easing_name);
+    }
+};
+
+namespace option_type
+{
+/**
+ * Parse the string as an animation description.
+ */
+template<>
+std::optional<animation_description_t> from_string<animation_description_t>(const std::string& value);
+
+/**
+ * Convert the given animation description to a string.
+ */
+template<>
+std::string to_string<animation_description_t>(const animation_description_t& value);
+}
+
+namespace animation
+{
 /**
  * A transition from start to end.
  */
@@ -46,6 +79,8 @@ class duration_t
      */
     duration_t(std::shared_ptr<wf::config::option_t<int>> length = nullptr,
         smoothing::smooth_function smooth = smoothing::circle);
+
+    duration_t(std::shared_ptr<wf::config::option_t<animation_description_t>> length);
 
     /* Copy-constructor */
     duration_t(const duration_t& other);
@@ -158,6 +193,8 @@ class simple_animation_t : public duration_t, public timed_transition_t
     simple_animation_t(
         std::shared_ptr<wf::config::option_t<int>> length = nullptr,
         smoothing::smooth_function smooth = smoothing::circle);
+
+    simple_animation_t(std::shared_ptr<wf::config::option_t<animation_description_t>> length);
 
     /**
      * Set the start and the end of the animation and start the duration.

--- a/src/duration.cpp
+++ b/src/duration.cpp
@@ -230,6 +230,42 @@ void wf::animation::simple_animation_t::animate()
 
 namespace wf
 {
+namespace animation
+{
+namespace smoothing
+{
+// Thanks https://github.com/MrRobinOfficial/EasingFunctions
+smooth_function ease_out_elastic = [] (double x) -> double
+{
+    float d = 1.0f;
+    float p = d * 0.6f;
+    float s;
+    float a = 0;
+
+    if (x == 0)
+    {
+        return 0;
+    }
+
+    if ((x /= d) == 1)
+    {
+        return 1;
+    }
+
+    if ((a == 0.0f) || (a < std::abs(1.0)))
+    {
+        a = 1.0;
+        s = p * 0.25f;
+    } else
+    {
+        s = p / (2 * std::acos(-1)) * std::asin(1.0 / a);
+    }
+
+    return (a * std::pow(2, -10 * x) * std::sin((x * d - s) * (2 * std::acos(-1)) / p) + 1.0);
+};
+}
+}
+
 namespace option_type
 {
 template<>
@@ -269,6 +305,7 @@ std::optional<animation_description_t> from_string<animation_description_t>(cons
         {"linear", animation::smoothing::linear},
         {"circle", animation::smoothing::circle},
         {"sigmoid", animation::smoothing::sigmoid},
+        {"easeOutElastic", animation::smoothing::ease_out_elastic},
     };
 
     if (!easing_map.count(result.easing_name))

--- a/src/xml.cpp
+++ b/src/xml.cpp
@@ -1,4 +1,3 @@
-#include <cstring>
 #include <wayfire/config/xml.hpp>
 #include <wayfire/config/types.hpp>
 #include <wayfire/util/log.hpp>
@@ -6,6 +5,7 @@
 
 #include "section-impl.hpp"
 #include "option-impl.hpp"
+#include "wayfire/util/duration.hpp"
 
 static std::optional<const xmlChar*> extract_value(xmlNodePtr node,
     std::string value_name)
@@ -188,6 +188,10 @@ std::shared_ptr<wf::config::option_base_t> parse_compound_option(xmlNodePtr node
             {
                 entries.push_back(std::make_unique<entry_t<wf::activatorbinding_t>>(
                     prefix, name, default_value));
+            } else if (type == "animation")
+            {
+                entries.push_back(std::make_unique<entry_t<wf::animation_description_t>>(
+                    prefix, name, default_value));
             } else
             {
                 LOGE("Could not parse ", node->doc->URL,
@@ -281,6 +285,9 @@ std::shared_ptr<wf::config::option_base_t> wf::config::xml::create_option_from_x
     } else if (type == "output::position")
     {
         option = create_option<wf::output_config::position_t>(name, default_value);
+    } else if (type == "animation")
+    {
+        option = create_option<wf::animation_description_t>(name, default_value);
     } else
     {
         LOGE("Could not parse ", node->doc->URL,

--- a/test/duration_test.cpp
+++ b/test/duration_test.cpp
@@ -11,8 +11,7 @@ using namespace wf::animation;
 
 TEST_CASE("wf::animation::duration_t")
 {
-    auto length = std::make_shared<option_t<int>>("length", 100);
-    duration_t duration{length, smoothing::linear};
+    duration_t duration;
 
     auto check_lifetime = [&] ()
     {
@@ -35,6 +34,23 @@ TEST_CASE("wf::animation::duration_t")
         CHECK(duration.running() == false);
         CHECK(duration.running() == false);
     };
+
+    SUBCASE("Int option")
+    {
+        auto length = std::make_shared<option_t<int>>("length", 100);
+        duration = duration_t{length, smoothing::linear};
+    }
+
+    SUBCASE("Animation option")
+    {
+        auto length = std::make_shared<option_t<wf::animation_description_t>>("length",
+            wf::animation_description_t{
+            .length_ms = 100,
+            .easing    = smoothing::linear,
+            .easing_name = "linear",
+        });
+        duration = duration_t{length};
+    }
 
     /* Check twice, so that we can test restarting */
     check_lifetime();

--- a/test/types_test.cpp
+++ b/test/types_test.cpp
@@ -1,3 +1,4 @@
+#include "wayfire/util/duration.hpp"
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
@@ -498,4 +499,41 @@ TEST_CASE("wf::output_config::position_t")
     CHECK(!from_string<pt>("test"));
     CHECK(!from_string<pt>("129 129"));
     CHECK(!from_string<pt>("129,"));
+}
+
+TEST_CASE("wf::animation::animation_description_t")
+{
+    using adt = wf::animation_description_t;
+    CHECK(!from_string<adt>("test"));
+    CHECK(!from_string<adt>("100ss"));
+    CHECK(!from_string<adt>("100 ms invalideasing"));
+    CHECK(!from_string<adt>("100 ms linear trailing"));
+
+    adt circle100 = {
+        .length_ms = 100,
+        .easing    = wf::animation::smoothing::circle,
+        .easing_name = "circle",
+    };
+    std::string circle100_str   = "100";
+    std::string circle100_str_2 = "100 ms";
+
+    adt linear8s = {
+        .length_ms = 8500,
+        .easing    = wf::animation::smoothing::linear,
+        .easing_name = "linear",
+    };
+    std::string linear8s_str = "8.5s linear";
+
+    adt sigmoid250ms = {
+        .length_ms = 250,
+        .easing    = wf::animation::smoothing::sigmoid,
+        .easing_name = "sigmoid",
+    };
+    std::string sigmoid250ms_str = "250ms sigmoid";
+
+    CHECK(from_string<adt>(circle100_str) == circle100);
+    CHECK(from_string<adt>(circle100_str_2) == circle100);
+    CHECK(from_string<adt>(linear8s_str) == linear8s);
+    CHECK(from_string<adt>(sigmoid250ms_str) == sigmoid250ms);
+    CHECK(to_string<adt>(sigmoid250ms) == sigmoid250ms_str);
 }


### PR DESCRIPTION
This PR adds a new config option type, animation.

It can be used instead of plain integers for animation durations.
In contrast to the basic integers, the new animation type uses a suffix to indicate the unit of time, `ms` or `s`.
It can also optionally override the easing function used for the particular animation.

As a test, this also adds a new elasticEaseOut easing function.

Fixes #6
