### PR TITLE
activators: add extension type bindings

### DIFF
--- a/include/wayfire/config/types.hpp
+++ b/include/wayfire/config/types.hpp
@@ -445,6 +445,11 @@ struct activatorbinding_t
     const std::vector<wf::hotspot_binding_t>& get_hotspots() const;
 
     /**
+     * @return A list of all unknown bindings which activate this binding.
+     */
+    const std::vector<std::string>& get_extensions() const;
+
+    /**
      * Check equality of two activator bindings.
      *
      * @return true if the two activator bindings are activated by the exact

--- a/test/types_test.cpp
+++ b/test/types_test.cpp
@@ -401,8 +401,13 @@ TEST_CASE("wf::activatorbinding_t")
         0, 1);
 
     CHECK(!from_string<activatorbinding_t>("<alt> KEY_K || <alt> KEY_U"));
-    CHECK(!from_string<activatorbinding_t>("<alt> KEY_K | thrash"));
     CHECK(!from_string<activatorbinding_t>("<alt> KEY_K |"));
+
+    auto with_ext = from_string<activatorbinding_t>("<alt> KEY_T | thrash");
+    CHECK(with_ext.has_value() == true);
+    CHECK(with_ext->get_extensions().size() == 1);
+    CHECK(with_ext->get_extensions().front() == "thrash");
+    CHECK(with_ext->has_match(kb1));
 }
 
 TEST_CASE("wf::output_config::mode_t")


### PR DESCRIPTION
Those are not parsed by wf-config, instead, Wayfire plugins determine their format.
