### PR TITLE
types: add two more edge-swipe types

### DIFF
--- a/include/wayfire/config/types.hpp
+++ b/include/wayfire/config/types.hpp
@@ -256,11 +256,21 @@ enum touch_gesture_type_t
     GESTURE_TYPE_NONE       = 0,
     /* Swipe gesture, i.e moving in one direction */
     GESTURE_TYPE_SWIPE      = 1,
-    /* Edge swipe, which is a swipe originating from the edge of the screen */
+    /* Edge swipe, which is a swipe originating from the edge of the screen 
+     * and is the main section in the center of the edge
+     */
     GESTURE_TYPE_EDGE_SWIPE = 2,
+    /* Edge swipe S1, which is a swipe originating from the edge of the screen 
+     * and is the first section of the edge before the main section
+     */
+    GESTURE_TYPE_EDGE_S1_SWIPE = 3,
+    /* Edge swipe S2, which is a swipe originating from the edge of the screen 
+     * and is the last section of the edge after the main section
+     */
+    GESTURE_TYPE_EDGE_S2_SWIPE = 4,
     /* Pinch gesture, multiple touch points coming closer or farther apart
      * from the center */
-    GESTURE_TYPE_PINCH      = 3,
+    GESTURE_TYPE_PINCH      = 5,
 };
 
 enum touch_gesture_direction_t

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -631,6 +631,14 @@ wf::touchgesture_t parse_gesture(const std::string& value)
         {
             type = wf::GESTURE_TYPE_EDGE_SWIPE;
             direction = parse_direction(tokens[1]);
+        } else if (tokens[0] == "edge-s1-swipe")
+        {
+            type = wf::GESTURE_TYPE_EDGE_S1_SWIPE;
+            direction = parse_direction(tokens[1]);
+        } else if (tokens[0] == "edge-s2-swipe")
+        {
+            type = wf::GESTURE_TYPE_EDGE_S2_SWIPE;
+            direction = parse_direction(tokens[1]);
         } else
         {
             throw std::domain_error("Invalid gesture type:" + tokens[0]);
@@ -697,9 +705,20 @@ std::string wf::option_type::to_string(const touchgesture_t& value)
         return "";
 
       case GESTURE_TYPE_EDGE_SWIPE:
-        result += "edge-";
+        result += "edge-swipe ";
+        result += direction_to_string(value.get_direction()) + " ";
+        break;
 
-      // fallthrough
+      case GESTURE_TYPE_EDGE_S1_SWIPE:
+        result += "edge-s1-swipe ";
+        result += direction_to_string(value.get_direction()) + " ";
+        break;
+
+      case GESTURE_TYPE_EDGE_S2_SWIPE:
+        result += "edge-s2-swipe ";
+        result += direction_to_string(value.get_direction()) + " ";
+        break;
+
       case GESTURE_TYPE_SWIPE:
         result += "swipe ";
         result += direction_to_string(value.get_direction()) + " ";

--- a/test/types_test.cpp
+++ b/test/types_test.cpp
@@ -241,6 +241,18 @@ TEST_CASE("wf::touchgesture_t")
     CHECK(binding5.get_direction() == wf::GESTURE_DIRECTION_OUT);
     CHECK(binding5.get_finger_count() == 2);
 
+    auto binding6 =
+        from_string<touchgesture_t>("edge-s1-swipe down 2").value();
+    CHECK(binding6.get_type() == wf::GESTURE_TYPE_EDGE_S1_SWIPE);
+    CHECK(binding6.get_direction() == wf::GESTURE_DIRECTION_DOWN);
+    CHECK(binding6.get_finger_count() == 2);
+
+    auto binding7 =
+        from_string<touchgesture_t>("edge-s2-swipe down 2").value();
+    CHECK(binding7.get_type() == wf::GESTURE_TYPE_EDGE_S2_SWIPE);
+    CHECK(binding7.get_direction() == wf::GESTURE_DIRECTION_DOWN);
+    CHECK(binding7.get_finger_count() == 2);
+
     auto empty = wf::touchgesture_t{wf::GESTURE_TYPE_NONE, 0, 0};
     CHECK(from_string<touchgesture_t>("none").value() == empty);
     CHECK(from_string<touchgesture_t>("disabled").value() == empty);
@@ -263,6 +275,10 @@ TEST_CASE("wf::touchgesture_t")
     CHECK(binding5 == wf::touchgesture_t{wf::GESTURE_TYPE_PINCH, 0, 2});
     CHECK(!(binding5 == wf::touchgesture_t{
         wf::GESTURE_TYPE_PINCH, wf::GESTURE_DIRECTION_IN, 2}));
+    CHECK(binding6 == wf::touchgesture_t{
+        wf::GESTURE_TYPE_EDGE_S1_SWIPE, wf::GESTURE_DIRECTION_DOWN, 2});
+    CHECK(binding7 == wf::touchgesture_t{
+        wf::GESTURE_TYPE_EDGE_S2_SWIPE, wf::GESTURE_DIRECTION_DOWN, 2});
 
     using wt_t = wf::touchgesture_t;
     CHECK(from_string<wt_t>(to_string<wt_t>(binding1)).value() == binding1);
@@ -270,6 +286,8 @@ TEST_CASE("wf::touchgesture_t")
     CHECK(from_string<wt_t>(to_string<wt_t>(binding3)).value() == binding3);
     CHECK(from_string<wt_t>(to_string<wt_t>(binding4)).value() == binding4);
     CHECK(from_string<wt_t>(to_string<wt_t>(binding5)).value() == binding5);
+    CHECK(from_string<wt_t>(to_string<wt_t>(binding6)).value() == binding6);
+    CHECK(from_string<wt_t>(to_string<wt_t>(binding7)).value() == binding7);
 }
 
 TEST_CASE("wf::hotspot_binding_t")


### PR DESCRIPTION
On touchscreen devices, we can gain more options to trigger some actions or activate plugins by splitting the edge_swipes into 3 sections.

edge-s1-swipe: first section of the edge before the main section, for example first 20% of the edge length.
edge-swipe: main section, for example 60% of edge length centered to the edge.
edge-s2-swipe: last section of the edge after the main section, for example last 20% of the edge length.