### PR TITLE
use ISO date format for log timestamps

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -107,7 +107,7 @@ static std::string get_formatted_date_time()
 
     struct tm buffer;
     localtime_r(&tt, &buffer);
-    out << std::put_time(&buffer, "%d-%m-%y %H:%M:%S.");
+    out << std::put_time(&buffer, "%Y-%m-%d %H:%M:%S.");
     out << std::setfill('0') << std::setw(3) << ms.count();
     return out.str();
 }

--- a/test/log_test.cpp
+++ b/test/log_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("wf::log::log_plain()")
 
         /* Remove date and current time, because it isn't reproducible. */
         int time_start_index = 2;
-        int time_length = 1 + 8 + 1 + 12; /* space + date + space + time */
+        int time_length = 1 + 10 + 1 + 12; /* space + date + space + time */
 
         REQUIRE(line.length() >= time_start_index + time_length);
         line.erase(time_start_index, time_length);


### PR DESCRIPTION
The old format is ambiguous. The locale-aware %x format is only available in C++20 and onwards but we are at C++17.

Fixes #76.