### PR TITLE
Don't copy accessed values in getters.

### DIFF
--- a/include/wayfire/config/compound-option.hpp
+++ b/include/wayfire/config/compound-option.hpp
@@ -47,19 +47,19 @@ class compound_option_entry_base_t
     virtual ~compound_option_entry_base_t() = default;
 
     /** @return The prefix of the tuple entry. */
-    std::string get_prefix() const
+    const std::string& get_prefix() const WF_LIFETIMEBOUND
     {
         return prefix;
     }
 
     /** @return The name of the tuple entry. */
-    std::string get_name() const
+    const std::string& get_name() const WF_LIFETIMEBOUND
     {
         return name;
     }
 
     /** @return The untyped default value of the tuple entry. */
-    std::optional<std::string> get_default_value() const
+    const std::optional<std::string>& get_default_value() const WF_LIFETIMEBOUND
     {
         return default_value;
     }
@@ -224,12 +224,12 @@ class compound_option_t : public option_base_t
     /**
      * Get the type information about entries in the option.
      */
-    const entries_t& get_entries() const;
+    const entries_t& get_entries() const WF_LIFETIMEBOUND;
 
     /**
      * Check if this compound option has named tuples.
      */
-    std::string get_type_hint() const
+    const std::string& get_type_hint() const WF_LIFETIMEBOUND
     {
         return list_type_hint;
     }

--- a/include/wayfire/config/option-wrapper.hpp
+++ b/include/wayfire/config/option-wrapper.hpp
@@ -95,12 +95,12 @@ class base_option_wrapper_t
     }
 
     /** Implicitly convertible to the value of the option */
-    operator Type() const
+    operator decltype(auto)() const WF_LIFETIMEBOUND
     {
         return this->value();
     }
 
-    Type value() const
+    decltype(auto) value() const WF_LIFETIMEBOUND
     {
         if constexpr (is_std_vector<Type>::value)
         {

--- a/include/wayfire/config/option.hpp
+++ b/include/wayfire/config/option.hpp
@@ -6,6 +6,12 @@
 
 #include <memory>
 
+#ifdef __clang__
+    #define WF_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+    #define WF_LIFETIMEBOUND
+#endif
+
 namespace wf
 {
 namespace config
@@ -21,7 +27,7 @@ class option_base_t
     option_base_t& operator =(const option_base_t& other) = delete;
 
     /** @return The name of the option */
-    std::string get_name() const;
+    const std::string& get_name() const WF_LIFETIMEBOUND;
 
     /** @return A copy of the option */
     virtual std::shared_ptr<option_base_t> clone_option() const = 0;
@@ -253,12 +259,12 @@ class option_t : public option_base_t,
         }
     }
 
-    Type get_value() const
+    const Type& get_value() const WF_LIFETIMEBOUND
     {
         return value;
     }
 
-    Type get_default_value() const
+    const Type& get_default_value() const WF_LIFETIMEBOUND
     {
         return default_value;
     }

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -5,7 +5,7 @@
 #include "option-impl.hpp"
 #include "wayfire/util/log.hpp"
 
-std::string wf::config::option_base_t::get_name() const
+const std::string& wf::config::option_base_t::get_name() const
 {
     return this->priv->name;
 }


### PR DESCRIPTION
The main concern is the case when `Type` is `std::string`. It is a common scenario when copy is unnecessary and for strings it is not too cheap and may cause allocations.

P.S. Sorry for the mess with commits and failed builds.