### PR TITLE
Add extra `AUTO` options

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,9 @@ jobs:
         - run: git clone http://github.com/ammen99/uncrustify
         - run: cd uncrustify && mkdir build && cd build && cmake ../ && make && cd ../../
         - run: curl https://raw.githubusercontent.com/WayfireWM/wayfire/master/uncrustify.ini > uncrustify.ini
-        - run: git ls-files | grep "hpp$\|cpp$" | xargs ./uncrustify/build/uncrustify -c uncrustify.ini --check
+        - run: git ls-files | grep "hpp$\|cpp$" | xargs ./uncrustify/build/uncrustify -c uncrustify.ini --no-backup --replace
+        - run: git diff
+        - run: git diff | diff - /dev/null &> /dev/null
   run_tests:
     name: "Check that tests do not break"
     runs-on: ubuntu-latest

--- a/include/wayfire/config/types.hpp
+++ b/include/wayfire/config/types.hpp
@@ -487,6 +487,10 @@ enum mode_type_t
 {
     /** Output was configured in automatic mode. */
     MODE_AUTO,
+    /** Output was configured with the biggest refresh rate. */
+    MODE_HIGHRR,
+    /** Output was configured with the biggest resolution. */
+    MODE_HIGHRES,
     /** Output was configured to be turned off. */
     MODE_OFF,
     /** Output was configured with a given resolution. */
@@ -502,11 +506,13 @@ enum mode_type_t
 struct mode_t
 {
     /**
-     * Initialize an OFF or AUTO mode.
+     * Initialize a mode.
      *
-     * @param auto_on If true, the created mode will be an AUTO mode.
+     * @param mode One of: MODE_AUTO, MODE_HIGHRR, MODE_HIGHRES, MODE_OFF. MODE_HIGHRR prioritizes refresh
+     * rate, MODE_HIGHRES prioritises resolution and MODE_AUTO chooses whatever the display tells it to use.
+     * @throws std::invalid_argument if the mode isn't MODE_AUTO, MODEHIGHRR, MODEHIGHRES or MODE_OFF.
      */
-    mode_t(bool auto_on = false);
+    mode_t(output_config::mode_type_t mode);
 
     /**
      * Initialize the mode with source self.

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1067,9 +1067,14 @@ std::string wf::option_type::to_string(
 }
 
 /* ------------------------- Output config types ---------------------------- */
-wf::output_config::mode_t::mode_t(bool auto_on)
+wf::output_config::mode_t::mode_t(output_config::mode_type_t mode)
 {
-    this->type = auto_on ? MODE_AUTO : MODE_OFF;
+    if ((mode == MODE_RESOLUTION) || (mode == MODE_MIRROR))
+    {
+        throw std::invalid_argument("Invalid mode definition");
+    }
+
+    this->type = mode;
 }
 
 wf::output_config::mode_t::mode_t(int32_t width, int32_t height, int32_t refresh)
@@ -1132,6 +1137,8 @@ bool wf::output_config::mode_t::operator ==(const mode_t& other) const
         return mirror_from == other.mirror_from;
 
       case MODE_AUTO:
+      case MODE_HIGHRR:
+      case MODE_HIGHRES:
       case MODE_OFF:
         return true;
     }
@@ -1145,12 +1152,22 @@ std::optional<wf::output_config::mode_t> wf::option_type::from_string(
 {
     if (string == "off")
     {
-        return wf::output_config::mode_t{false};
+        return wf::output_config::mode_t{wf::output_config::mode_type_t::MODE_OFF};
     }
 
     if ((string == "auto") || (string == "default"))
     {
-        return wf::output_config::mode_t{true};
+        return wf::output_config::mode_t{wf::output_config::mode_type_t::MODE_AUTO};
+    }
+
+    if ((string == "highres"))
+    {
+        return wf::output_config::mode_t{wf::output_config::mode_type_t::MODE_HIGHRES};
+    }
+
+    if ((string == "highrr"))
+    {
+        return wf::output_config::mode_t{wf::output_config::mode_type_t::MODE_HIGHRR};
     }
 
     if (string.substr(0, 6) == "mirror")
@@ -1203,6 +1220,12 @@ std::string wf::option_type::to_string(const output_config::mode_t& value)
     {
       case output_config::MODE_AUTO:
         return "auto";
+
+      case output_config::MODE_HIGHRR:
+        return "highrr";
+
+      case output_config::MODE_HIGHRES:
+        return "highres";
 
       case output_config::MODE_OFF:
         return "off";

--- a/test/types_test.cpp
+++ b/test/types_test.cpp
@@ -416,9 +416,11 @@ TEST_CASE("wf::output_config::mode_t")
     using namespace wf::output_config;
 
     std::vector<mt> modes = {
-        mt{true},
-        mt{true},
-        mt{false},
+        mt{MODE_HIGHRES},
+        mt{MODE_HIGHRR},
+        mt{MODE_AUTO},
+        mt{MODE_AUTO},
+        mt{MODE_OFF},
         mt{1920, 1080, 0},
         mt{1920, 1080, 59000},
         mt{1920, 1080, 59000},
@@ -426,6 +428,8 @@ TEST_CASE("wf::output_config::mode_t")
     };
 
     std::vector<mode_type_t> types = {
+        MODE_HIGHRES,
+        MODE_HIGHRR,
         MODE_AUTO,
         MODE_AUTO,
         MODE_OFF,
@@ -436,6 +440,8 @@ TEST_CASE("wf::output_config::mode_t")
     };
 
     std::vector<std::string> desc = {
+        "highres",
+        "highrr",
         "auto",
         "default",
         "off",
@@ -452,10 +458,10 @@ TEST_CASE("wf::output_config::mode_t")
         "1920 1080",
     };
 
-    CHECK(modes[3].get_refresh() == 0);
-    CHECK(modes[4].get_refresh() == 59000);
-    CHECK(modes[5].get_refresh() == 59000);
-    CHECK(modes[6].get_mirror_from() == "eDP-1");
+    CHECK(modes[5].get_refresh() == 0);
+    CHECK(modes[6].get_refresh() == 59000);
+    CHECK(modes[7].get_refresh() == 59000);
+    CHECK(modes[8].get_mirror_from() == "eDP-1");
 
     for (size_t i = 0; i < modes.size(); i++)
     {


### PR DESCRIPTION
Using the `preferred` video mode is a nice heuristic. However, some monitors and TV's preferred mode is not up to the user's preference.

This adds two modes, `AUTO_HIGHRR` and `AUTO_HIGHRES`. 
The former chooses the highest refresh rate first **then** chooses the highest resolution that satisfies the initial constraint.
The latter just scrapes the barrel with the video modes. It chooses the "biggest" one.

I am not sure if the function `wf::output_config::mode_t::mode_t` in `src/types.cpp` needs to be changed.