### PR TITLE
chore: make sure `uncrustify` isn't tracked by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+uncrustify


### PR DESCRIPTION
It was really easy to miss, especially if you use vscode.

Has also happened [here](https://github.com/WayfireWM/wf-shell/pull/347). Not sure how i'd go to make sure this doesn't happen in any way shape or form in the future.

I was uncrustifying with distrobox also, which might play a role in that.